### PR TITLE
Change footer icon and github link

### DIFF
--- a/public/portfolio_shared_data.json
+++ b/public/portfolio_shared_data.json
@@ -5,13 +5,13 @@
       "social": [
         {
           "name": "github",
-          "url": "https://github.com",
+          "url": "https://github.com/DavidMatalik",
           "class": "fab fa-github"
         },
         {
-          "name": "instagram",
-          "url": "https://www.instagram.com",
-          "class": "fab fa-instagram"
+          "name": "linkedin",
+          "url": "https://www.linkedin.com/",
+          "class": "fab fa-linkedin"
         }
       ],
       "image": "myProfile.jpg"


### PR DESCRIPTION
The name is still displayed as Davina Griess, but it depends on the name put into file portfolio_shared_data.json. This name is already adjusted in another open PR.